### PR TITLE
patch: Update output actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,5 +43,5 @@ jobs:
           version: ${{ env.TAG }}
           google_credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
-      - id: return-tag
-        run: echo "::set-output name=tag::${{ env.TAG }}"
+      - name: Return tag
+        run: echo "tag=${{ env.TAG }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -55,5 +55,5 @@ jobs:
           version: ${{ env.TAG }}
           google_credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
-      - id: return-tag
-        run: echo "::set-output name=tag::${{ env.TAG }}"
+      - name: Return tag
+        run: echo "tag=${{ env.TAG }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/