### PR TITLE
Add gradle-publish workflow

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,59 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+      sonar_scan:
+        required: false
+        default: false
+        type: boolean
+      with_timestamp:
+        required: false
+        default: true
+        type: boolean
+      gradle_publish:
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.return-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+
+      - name: Checkout shared setup
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GIT_PAT }}
+          repository: IndependentIP/actions
+          path: actions
+
+      - uses: ./actions/gradle-build
+
+      - if: ${{ inputs.sonar_scan }}
+        uses: ./actions/sonarcloud-scan-gradle
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          sonarcloud_token: ${{ secrets.SONAR_TOKEN }}
+
+      - uses: ./actions/get-tag
+        with:
+          branch: ${{ inputs.branch }}
+          with_timestamp: ${{ inputs.with_timestamp }}
+
+      - if: ${{ inputs.gradle_publish }}
+        uses: ./actions/gradle-publish
+        with:
+          version: ${{ env.TAG }}
+          nexus_url: ${{ secrets.NEXUS_URL }}
+          nexus_user: ${{ secrets.NEXUS_USER }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: true
         type: boolean
-      gradle_publish:
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   build:
@@ -50,8 +46,7 @@ jobs:
           branch: ${{ inputs.branch }}
           with_timestamp: ${{ inputs.with_timestamp }}
 
-      - if: ${{ inputs.gradle_publish }}
-        uses: ./actions/gradle-publish
+      - uses: ./actions/gradle-publish
         with:
           version: ${{ env.TAG }}
           nexus_url: ${{ secrets.NEXUS_URL }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -49,6 +49,5 @@ jobs:
       - uses: ./actions/gradle-publish
         with:
           version: ${{ env.TAG }}
-          nexus_url: ${{ secrets.NEXUS_URL }}
           nexus_user: ${{ secrets.NEXUS_USER }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          nexus_password: ${{ secrets.NEXUS_PASS }}


### PR DESCRIPTION
I had two ideas:
1. Separate publish workflow from build workflow
2. Modify current workflow to make it universal

Separate publish workflow helps us to keep main workflow clean and not overcomplicated, but leads to duplicated code in gradle-build and gradle-publish workflows (gradle-publish will exclude docker-build step and will include gradle-publish step).

In the other hand modifying our current workflow makes it universal to use and configurable. Al.so we won't have code duplication across the two workflows.

We with Oren decided to go with separate gradle-publish.yml workflow.