### PR TITLE
Use SONARCLOUD_TOKEN instead of SONAR_TOKEN

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -74,7 +74,7 @@ jobs:
         uses: ./actions/sonarcloud-scan-gradle
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          sonarcloud_token: ${{ secrets.SONAR_TOKEN }}
+          sonarcloud_token: ${{ secrets.SONARCLOUD_TOKEN }}
 
       - uses: ./actions/get-tag
         with:


### PR DESCRIPTION
It's globally defined at the organizational level so should work for all repos OOTB. Currently, the workflow assumes you have the `SONAR_TOKEN` secret defined for your repo.